### PR TITLE
Use zerolog for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/rs/zerolog v1.19.0
 	github.com/spf13/viper v1.7.0
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,9 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -299,6 +302,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"hash/fnv"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -34,7 +33,7 @@ func GetOutboundIP() net.IP {
 	// long as it's in a public subnet
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	defer conn.Close()
 
@@ -88,15 +87,13 @@ func buildClusterConfig(dataDir string, raftAddr string) *ClusterConfig {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			// Config file was found but another error was produced
-			log.Fatalln("Error parsing config file:", err)
+			panic(err)
 		}
-		log.Println("No config file found -- defaulting to single-node configuration")
+		// No config file found -- defaulting to single-node configuration
 	} else {
 		// Config file found and successfully parsed
 		if viper.GetString("configuration.mode") == "multi" {
 			mode = MultiNode
-			// fmt.Println("Multi-node configuration. Members:")
-
 			svs := viper.GetStringSlice("configuration.members")
 			if len(svs) < 2 {
 				panic(ErrInvalidMultiConfig)
@@ -119,9 +116,7 @@ func buildClusterConfig(dataDir string, raftAddr string) *ClusterConfig {
 					panic(ErrSelfNotInConfig)
 				}
 			}
-		} else {
-			// fmt.Println("Single-node configuration")
-		}
+		} // else single node configuration
 	}
 	return &ClusterConfig{
 		Mode:    mode,
@@ -143,8 +138,6 @@ func BuildServerConfig() *ServerConfig {
 
 	raftAddr := fmt.Sprintf("%s:%d", ip, raftPort)
 	clientAddr := fmt.Sprintf("%s:%d", ip, clientPort)
-	// log.Println("Cluster interface: " + raftAddr)
-	// log.Println("Client interface:  " + clientAddr)
 
 	if dataDir == "" {
 		hash := fnv.New32()
@@ -154,7 +147,6 @@ func BuildServerConfig() *ServerConfig {
 		homeDir, _ := os.UserHomeDir()
 		dataDir = filepath.Join(homeDir, ".leifdb", hashString)
 	}
-	// log.Println("Data dir: ", dataDir)
 	err2 := util.EnsureDirectory(dataDir)
 	if err2 != nil {
 		panic(err2)

--- a/internal/raftserver/rpc.go
+++ b/internal/raftserver/rpc.go
@@ -2,11 +2,11 @@ package raftserver
 
 import (
 	"context"
-	"log"
 	"net"
 
 	"github.com/btmorr/leifdb/internal/node"
 	"github.com/btmorr/leifdb/internal/raft"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 )
 
@@ -17,13 +17,13 @@ type server struct {
 
 // RequestVote handles RPC vote requests from other nodes
 func (s *server) RequestVote(ctx context.Context, v *raft.VoteRequest) (*raft.VoteReply, error) {
-	log.Println("Received vote request:", v)
+	log.Debug().Msgf("Received vote request: %v", v)
 	return s.Node.HandleVote(v), nil
 }
 
 // RequestVote handles RPC log-append requests from other nodes
 func (s *server) AppendLogs(ctx context.Context, a *raft.AppendRequest) (*raft.AppendReply, error) {
-	log.Println("Received append request:", a)
+	log.Debug().Msgf("Received append request: %v", a)
 	return s.Node.HandleAppend(a), nil
 }
 
@@ -32,11 +32,11 @@ func (s *server) AppendLogs(ctx context.Context, a *raft.AppendRequest) (*raft.A
 func StartRaftServer(port string, n *node.Node) {
 	lis, err := net.Listen("tcp", port)
 	if err != nil {
-		log.Fatalln("Cluster interface failed to bind:", err)
+		log.Fatal().Err(err).Msg("Cluster interface failed to bind")
 	}
 	s := grpc.NewServer()
 	raft.RegisterRaftServer(s, &server{Node: n})
 	if err := s.Serve(lis); err != nil {
-		log.Fatalln("Failed to serve:", err)
+		log.Fatal().Err(err).Msg("Failed to serve")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,12 +6,15 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/btmorr/leifdb/internal/configuration"
 	"github.com/btmorr/leifdb/internal/database"
 	"github.com/btmorr/leifdb/internal/node"
 	"github.com/btmorr/leifdb/internal/raftserver"
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -85,7 +88,17 @@ func buildRouter(n *node.Node) *gin.Engine {
 	return router
 }
 
+// For more human-readable logs, uncomment the following function and add the
+// associated imports ("github.com/rs/zerolog", and "os")
+func init() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{
+		Out:        os.Stderr,
+		TimeFormat: time.RFC3339})
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+}
+
 func main() {
+
 	cfg := configuration.BuildServerConfig()
 	fmt.Printf("Configuration:\n%+v\n\n", *cfg)
 


### PR DESCRIPTION
Before:

```
Configuration:
&{IpAddr:192.168.1.21 DataDir:/Users/toma/.leifdb/077fbfc5 RaftPort:16990 RaftAddr:192.168.1.21:16990 CleintPort:8080 ClientAddr:192.168.1.21:8080 ClusterCfg:0xc0001047b0}
2020/06/02 21:59:23 Current term: 12 - Voted for: 192.168.1.21:16990
2020/06/02 21:59:23 Loaded 0 logs
2020/06/02 21:59:23 Election timeout:  299ms
2020/06/02 21:59:24 Starting Election
2020/06/02 21:59:24 Becoming candidate
2020/06/02 21:59:24 	New Term:  13
2020/06/02 21:59:24 	N other nodes:  0
2020/06/02 21:59:24 	Votes needed:  1
2020/06/02 21:59:24 Election succeeded [ 1 out of 1 needed]
2020/06/02 21:59:24 Becoming leader
2020/06/02 21:59:24 Stopping election timer, starting append ticker
.........
```

After:

```
Configuration:
{IpAddr:192.168.1.21 DataDir:/Users/toma/.leifdb/077fbfc5 RaftPort:16990 RaftAddr:192.168.1.21:16990 CleintPort:8080 ClientAddr:192.168.1.21:8080 ClusterCfg:0xc000402630}

2020-06-02T22:17:20-04:00 INF On load Term=14 Vote=192.168.1.21:16990 nLogs=0
2020-06-02T22:17:20-04:00 INF Election timeout: 271ms
2020-06-02T22:17:20-04:00 INF Becoming candidate Term=15 clusterSize=0 needed=1
2020-06-02T22:17:20-04:00 INF Election succeeded got=1 needed=1 success=true
............
```

Or, with the `init` function in main.go commented out (better performance, structured logs which would be better for machine processing or sending up to an aggregator):

```
Configuration:
{IpAddr:192.168.1.21 DataDir:/Users/toma/.leifdb/077fbfc5 RaftPort:16990 RaftAddr:192.168.1.21:16990 CleintPort:8080 ClientAddr:192.168.1.21:8080 ClusterCfg:0xc000402660}

{"level":"info","Term":11,"Vote":"192.168.1.21:16990","nLogs":0,"time":"2020-06-02T21:58:24-04:00","message":"On load"}
{"level":"info","time":"2020-06-02T21:58:24-04:00","message":"Election timeout: 191ms"}
{"level":"trace","time":"2020-06-02T21:58:24-04:00","message":"First election timer"}
{"level":"trace","time":"2020-06-02T21:58:24-04:00","message":"Starting Election"}
{"level":"info","Term":12,"clusterSize":0,"needed":1,"time":"2020-06-02T21:58:24-04:00","message":"Becoming candidate"}
{"level":"info","needed":1,"got":1,"success":true,"time":"2020-06-02T21:58:24-04:00","message":"Election succeeded"}
{"level":"trace","time":"2020-06-02T21:58:24-04:00","message":"Becoming leader"}
{"level":"debug","time":"2020-06-02T21:58:24-04:00","message":"Stopping election timer, starting append ticker"}
.......
```
