### PR TITLE
Use log-append and commit logic to update database

### DIFF
--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,0 +1,57 @@
+package node
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	db "github.com/btmorr/leifdb/internal/database"
+	"github.com/btmorr/leifdb/internal/raft"
+	"github.com/btmorr/leifdb/internal/util"
+	"google.golang.org/grpc"
+)
+
+// checkForeignNodeMock is used to skip membership checks during test, so that a
+// Node will perform raft operations without creating a full multi-node config
+func checkForeignNodeMock(addr string, known map[string]*ForeignNode) bool {
+	return true
+}
+
+type MockRaftClient struct {
+	cc raft.RaftClient
+}
+
+func (m *MockRaftClient) RequestVote(ctx context.Context, in *raft.VoteRequest, opts ...grpc.CallOption) (*raft.VoteReply, error) {
+	return &raft.VoteReply{Term: in.Term, VoteGranted: true}, nil
+}
+func (m *MockRaftClient) AppendLogs(ctx context.Context, in *raft.AppendRequest, opts ...grpc.CallOption) (*raft.AppendReply, error) {
+	return &raft.AppendReply{Term: in.Term, Success: true}, nil
+}
+
+// setupNode configures a Database and a Node for test, and creates
+// a test directory that is automatically cleaned up after each test
+func setupNode(t *testing.T) *Node {
+	addr := "localhost:8080"
+
+	testDir, err := util.CreateTmpDir(".tmp-leifdb")
+	if err != nil {
+		log.Fatalln("Error creating test dir:", err)
+	}
+	t.Cleanup(func() {
+		util.RemoveTmpDir(testDir)
+	})
+
+	store := db.NewDatabase()
+
+	config := NewNodeConfig(testDir, addr)
+	n, _ := NewNode(config, store)
+	n.CheckForeignNode = checkForeignNodeMock
+	return n
+}
+
+func TestAddNewLog(t *testing.T) {
+	n := setupNode(t)
+	// Simulating node in leader position, rather than adding a time.Sleep
+	n.DoElection()
+
+}

--- a/internal/raftserver/rpc_test.go
+++ b/internal/raftserver/rpc_test.go
@@ -40,9 +40,9 @@ func setupServer(t *testing.T) *node.Node {
 	store := db.NewDatabase()
 
 	config := node.NewNodeConfig(testDir, addr)
-	node, _ := node.NewNode(config, store)
-	node.CheckForeignNode = checkForeignNodeMock
-	return node
+	n, _ := node.NewNode(config, store)
+	n.CheckForeignNode = checkForeignNodeMock
+	return n
 }
 
 // CompareLogs traverses a pair of LogStores to check for equality by value
@@ -269,7 +269,7 @@ func TestAppend(t *testing.T) {
 			sendId:          validLeaderId,
 			sendPrevIdx:     prevIdx,
 			sendPrevTerm:    prevTerm,
-			sendCommit:      2,
+			sendCommit:      1,
 			sendRecords:     make([]*raft.LogRecord, 0, 0),
 			expectedSuccess: true,
 			expectedStore:   updatedLog,
@@ -284,7 +284,7 @@ func TestAppend(t *testing.T) {
 			sendId:          validLeaderId,
 			sendPrevIdx:     prevIdx,
 			sendPrevTerm:    prevTerm,
-			sendCommit:      int64(len(updatedLog.Entries)),
+			sendCommit:      int64(len(updatedLog.Entries) - 1),
 			sendRecords:     make([]*raft.LogRecord, 0, 0),
 			expectedSuccess: true,
 			expectedStore:   updatedLog,

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -33,9 +34,10 @@ func setupServer(t *testing.T) (*gin.Engine, *node.Node) {
 	store := db.NewDatabase()
 
 	config := node.NewNodeConfig(testDir, addr)
-	node, _ := node.NewNode(config, store)
-	router := buildRouter(node)
-	return router, node
+	n, _ := node.NewNode(config, store)
+	router := buildRouter(n)
+	n.DoElection()
+	return router, n
 }
 
 func TestHealthRoute(t *testing.T) {
@@ -64,6 +66,8 @@ func TestReadAfterWrite(t *testing.T) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/db/stuff", br1)
 	router.ServeHTTP(w, req)
+
+	fmt.Printf("Response: %+v\n", w)
 
 	if w.Code != http.StatusOK {
 		t.Error("Non-200 health status in POST:", w.Code)


### PR DESCRIPTION
This PR modifies the server to use log-append and commit logic to update database. 

Multi-node interactions are not fully vetted (forming correct commitIndex number for requests, for instance), though if a server sends correctly-formed append-logs messages they are handled correctly by followers. 