### PR TITLE
Add connection validation and display status card / bar

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -19,6 +19,11 @@
   color: #61dafb;
 }
 
+.site-card-border-less-wrapper {
+  padding: 30px;
+  background: #ececec;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);


### PR DESCRIPTION
When merged, this PR will:

- Check connection when you enter an address into the search bar on the admin page
- Render a card with host status on the admin page
- Render a bar with host status on the database page

Success, on Admin page:
![admin-success](https://user-images.githubusercontent.com/5034659/83977293-90d71c00-a8cd-11ea-980a-28607322cad5.png)

Success, on Database page:
![db-success](https://user-images.githubusercontent.com/5034659/83977300-992f5700-a8cd-11ea-8801-b653086ddf57.png)

Failure, on Admin page:
![admin-failure](https://user-images.githubusercontent.com/5034659/83977305-9f253800-a8cd-11ea-851b-83e7c3772279.png)
