### PR TITLE
Fix index out of range error in reconcileLogs

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -706,6 +706,10 @@ func reconcileLogs(logStore *raft.LogStore, body *raft.AppendRequest) *raft.LogS
 	if body.PrevLogIndex < int64(len(logStore.Entries)-1) {
 		overlappingEntries := logStore.Entries[body.PrevLogIndex+1:]
 		for i, rec := range overlappingEntries {
+			if i >= len(body.Entries) {
+				mismatchIdx = body.PrevLogIndex + int64(i)
+				break
+			}
 			if rec.Term != body.Entries[i].Term {
 				mismatchIdx = body.PrevLogIndex + 1 + int64(i)
 				break


### PR DESCRIPTION
When merged, this PR will:

- Prevent a panic in `reconcileLogs` due to possible index out of range

Closes #57.
