### PR TITLE
Rename test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ binary_prefix = leifdb-
 .PHONY: test
 test: app
 	go test -tags=unit -coverprofile=coverage.out ./...
-	-go test -tags=xfail -coverprofile=xfail_coverage.out ./...
+	go test -tags=mgmttest -coverprofile=mgmttest_coverage.out ./...
 
 .PHONY: viewcoverage
 viewcoverage: coverage.out
 	go tool cover -html=coverage.out
-	go tool cover -html=xfail_coverage.out
+	go tool cover -html=mgmttest_coverage.out
 
 .PHONY: benchmark
 benchmark:
@@ -31,7 +31,7 @@ app: clean
 	gofmt -w -s .
 	go vet
 	go fix ./...
-	go build -tags=unit,xfail -o $(binary_prefix)$(version)
+	go build -tags=unit,mgmttest -o $(binary_prefix)$(version)
 
 .PHONY: protobuf
 protobuf:

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ To build and run the app manually on Linux/Unix:
 
 ```
 go clean
-go build -tags=unit,xfail -o leifdb
+go build -tags=unit,mgmttest -o leifdb
 ```
 
 On Windows:
 ```
 go clean
-go build -tags=unit,xfail -o leifdb.exe
+go build -tags=unit,mgmttest -o leifdb.exe
 ```
 
 Responses to client endpoints are string-formatted.
@@ -64,7 +64,8 @@ Responses to client endpoints are string-formatted.
 To manually run the test suite:
 
 ```
-go test -tags=unit,xfail ./...
+go test -tags=unit ./...
+go test -tags=mgmttest ./...
 ```
 
 After building the binary, to find out what command line parameters are available:

--- a/internal/mgmt/statemanager_test.go
+++ b/internal/mgmt/statemanager_test.go
@@ -1,9 +1,8 @@
-// +build xfail
+// +build mgmttest
 
-// This test is timing-dependent, and can be flaky on a given run. Until we
-// have a better way of testing the timer logic, this test is run separately on
-// CI such that a failure on this step doesn't count as a failed build (but
-// will still be visible in the logs)
+// This test is timing-dependent, and fails if run along with the rest of the
+// test suite. Until we have a better way of testing the timer logic, this test
+// is run separately on CI
 
 package mgmt
 


### PR DESCRIPTION
When merged, this PR will:

- Rename the "xfail" test suite to "mgmttest", since it turns out that it is not expected to fail, but it consistently fails if run along with the rest of the test suite
- Make the "mgmttest" suite required for passing test