### PR TITLE
Add basic dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 leifdb-*
+build
 
 # Test binary, built with `go test -c`
 *.test
@@ -34,4 +35,3 @@ ui/coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ADD build/leifdb /
+ADD build/config.toml /.leifdb/config.toml
+CMD ["/leifdb", "--data", ".leifdb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM scratch
 ADD build/leifdb /
-ADD build/config.toml /.leifdb/config.toml
-CMD ["/leifdb", "--data", ".leifdb"]
+CMD ["/leifdb"]
+
+# Build:
+#   docker build -t <tag>:<version> .
+# Example run, with 3 containers at IP addresses <container_1_ip>, <container_2_ip>, and <container_3_ip>:
+#   docker run -it <tag>:<version> \
+#     -e LEIFDB_MEMBER_NODES="<container_1_ip>:16990,<container_2_ip>:16990,<container_3_ip>:16990" \
+#     -p 8080:8080 -p 16990:16990

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ benchmark:
 .PHONY: clean
 clean:
 	go clean
+	rm -rf ./build || true
 	rm ./$(binary_prefix)* || true
 
 .PHONY: install
@@ -39,6 +40,11 @@ protobuf:
 	cp ./github.com/btmorr/leifdb/internal/raft/* ./internal/raft/
 	rm -rf ./github.com
 
-.PHONY: run
-run: leifdb-$(version)
-	./leifdb-$(version) $(run_opts)
+# Note this is not working completely correctly now, as the default config file
+# does not work out of the box--revisit after consolidating configration and
+# making it more amenable to containerization
+.PHONY: container
+container:
+	env GOOS=linux GOARCH=amd64 go build -o build/leifdb
+	cp config/default_config.toml build/config.toml
+	docker build -t leifdb:0 .

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,4 @@ protobuf:
 .PHONY: container
 container:
 	env GOOS=linux GOARCH=amd64 go build -o build/leifdb
-	cp config/default_config.toml build/config.toml
 	docker build -t leifdb:0 .


### PR DESCRIPTION
When merged, this PR will:

- Add a basic Dockerfile for running the server in a container
- Add a make task to cross-compile a binary for Linux and put it in the right place to be found by the docker build