### PR TITLE
Redirect to new leader if we believe we aren't the leader during a write

### DIFF
--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -319,7 +319,7 @@ func TestCommitLogs(t *testing.T) {
 				"Hermione": "present"}}}
 
 	n := setupNode(t)
-	n.setTerm(currentTerm, currentLead)
+	n.SetTerm(currentTerm, currentLead)
 
 	for _, tc := range testCases {
 		n.HandleAppend(tc.Request)
@@ -337,7 +337,7 @@ func TestUpdateTermViaAppend(t *testing.T) {
 
 	startTerm := int64(3)
 	otherNodeId := "localhost:8181"
-	n.setTerm(startTerm, otherNodeId)
+	n.SetTerm(startTerm, otherNodeId)
 
 	newTerm := startTerm + 1
 	req := &raft.AppendRequest{

--- a/main.go
+++ b/main.go
@@ -113,8 +113,7 @@ func (ctl *Controller) handleWrite(c *gin.Context) {
 	// Short circuit, if we are not the leader right now, we return
 	// a redirect to the current presumptive leader
 	if ctl.Node.State != mgmt.Leader {
-		c.String(http.StatusTemporaryRedirect, "")
-		c.Header("Location", fmt.Sprintf("http://%s/db/%s", ctl.Node.RedirectLeader(), key))
+		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("http://%s/db/%s", ctl.Node.RedirectLeader(), key))
 		return
 	}
 
@@ -143,6 +142,13 @@ type DeleteResponse struct {
 func (ctl *Controller) handleDelete(c *gin.Context) {
 	// todo: add redirect if not leader, use "Location:" header
 	key := c.Param("key")
+
+	// Short circuit, if we are not the leader right now, we return
+	// a redirect to the current presumptive leader
+	if ctl.Node.State != mgmt.Leader {
+		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("http://%s/db/%s", ctl.Node.RedirectLeader(), key))
+		return
+	}
 
 	if err := ctl.Node.Delete(key); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
Redirect to new leader if we believe we aren't the leader during a write

- Redirect writes to a new leader if we aren't the current leader for PUT and DELETE operations


Closes #44.

cc: @btmorr

<!--
  Thanks for taking the time to open a pull request! Please take the
  suggested form above as a suggestion, and revise however makes
  sense for your proposed contribution. If you have any questions,
  take a look in the Contributing Guide, or go ahead and post and
  the maintainers will help out as much as possible.

  https://github.com/btmorr/leifdb/blob/edge/CONTRIBUTING.md
-->
