### PR TITLE
Update install task and documentation for protobuf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ go install google.golang.org/protobuf/cmd/protoc-gen-go
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ```
 
+If you have trouble finding the binary, on a Unix or Linux system you can try:
+
+```
+find $(go env GOPATH) -name protoc-gen-go
+```
+
 Additionally this repo includes a Makefile with tasks for common workflows. Your OS may already have [make](https://www.gnu.org/software/make/) installed (you can check on a Linux/Unix system using `which make` or on Windows using `Get-Command make` in PowerShell). If you don't have it installed, you can get it via a package manager (ex: `yum` for Centos, `apt` for Debian/Ubuntu, [`brew`](https://brew.sh) for MacOS, or [Chocolatey](https://chocolatey.org) for Windows).
 
 Especially on Windows, there are many ways of installing make (such as with [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about), getting a binary from the [GNU Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm) page, etc.--I'm not going to cover them all here, but you can use what works best for you.
@@ -57,9 +63,9 @@ The version number is currently determined by a variable in "version.sh". The `m
 
 ## Maintainers
 
-[Toma Morris](https://github.com/btmorr)
+- [Toma Morris](https://github.com/btmorr)
 
 ## Contributors
 
-[Toma Morris](https://github.com/btmorr)
-[Suhail Patel](https://github.com/suhailpatel)
+- [Toma Morris](https://github.com/btmorr)
+- [Suhail Patel](https://github.com/suhailpatel)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 version = $(shell bash ./version.sh)
-run_opts ?=
+
+# Note: be careful with values for `binary_prefix`, because of how it is used
+# in the "clean" task--it will delete any files with this prefix
 binary_prefix = leifdb-
 
 .PHONY: test
@@ -23,7 +25,9 @@ clean:
 
 .PHONY: install
 install:
-	go get -u github.com/swaggo/swag/cmd/swag
+	go install github.com/swaggo/swag/cmd/swag
+	go install google.golang.org/protobuf/cmd/protoc-gen-go
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
 .PHONY: app
 app: clean
@@ -38,7 +42,3 @@ protobuf:
 	mkdir -p ./internal/raft
 	cp ./github.com/btmorr/leifdb/internal/raft/* ./internal/raft/
 	rm -rf ./github.com
-
-.PHONY: run
-run: leifdb-$(version)
-	./leifdb-$(version) $(run_opts)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200701221012-f01a4bec33ec // indirect
 	google.golang.org/grpc v1.29.1
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555 // indirect
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,9 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555 h1:HYZFXlXJqim8gcoUICZN9oGXFPtw2GEBFm3ay9KZnxU=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200630190442-3de8449f8555/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
When merged, this PR will:

- Update `make install` task to install tools needed for `make protobuf`
- Update `make install` task to use `go install` for swag instead of `go get -u`
- Update documentation on protobuf portion of developer setup in contributing
