### PR TITLE
Avoid term update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+.idea
 leifdb-*
 build
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ version = $(shell bash ./version.sh)
 # Note: be careful with values for `binary_prefix`, because of how it is used
 # in the "clean" task--it will delete any files with this prefix
 binary_prefix = leifdb-
+tag ?= 0
 
 .PHONY: test
 test: app
@@ -47,4 +48,4 @@ protobuf:
 .PHONY: container
 container:
 	env GOOS=linux GOARCH=amd64 go build -o build/leifdb
-	docker build -t leifdb:0 .
+	docker build -t leifdb:$(tag) .

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ go clean
 go build -tags=unit,mgmttest -o leifdb.exe
 ```
 
-Responses to client endpoints are string-formatted.
-
 To manually run the test suite:
 
 ```
@@ -135,10 +133,10 @@ In order to interact with other members of a raft cluster, each node must know t
 - `LEIFDB_MODE`: must be "multi" (default is "single")
 - `LEIFDB_MEMBER_NODES`: must be a comma-separated list of addresses for other nodes, such as "10.10.0.2:16990,10.10.0.3:16990,10.10.0.4:16990"
 
-To run a cluster on one machine, make 3 directories named "/data/a", "/data/b", and "/data/c". Replace "10.10.0.x" with either "localhost" or your computer's preferred IP (can get it from `ifconfig` on Unix/Linux or `ipconfig` on Windows, or from an error message by running a server with the config file as written--better methods forthcoming). Then open three terminal windows and execute these in each:
+To run a cluster on one machine, make 3 directories named "~/testdata/a", "~/testdata/b", and "~/testdata/c". Replace "10.10.0.x" with either "localhost" or your computer's preferred IP (can get it from `ifconfig` on Unix/Linux or `ipconfig` on Windows, or from an error message by running a server with the config file as written--better methods forthcoming). Then open three terminal windows and execute these in each:
 
 ```
-env LEIFDB_DATA_DIR=/data/a \
+env LEIFDB_DATA_DIR=~/testdata/a \
   LEIFDB_MODE=multi \
   LEIFDB_MEMBER_NODES="localhost:16990,localhost:16991,localhost:16992" \
   LEIFDB_HOST=localhost \
@@ -148,7 +146,7 @@ env LEIFDB_DATA_DIR=/data/a \
 ```
 
 ```
-env LEIFDB_DATA_DIR=/data/b \
+env LEIFDB_DATA_DIR=~/testdata/b \
   LEIFDB_MODE=multi \
   LEIFDB_MEMBER_NODES="localhost:16990,localhost:16991,localhost:16992" \
   LEIFDB_HOST=localhost \
@@ -158,7 +156,7 @@ env LEIFDB_DATA_DIR=/data/b \
 ```
 
 ```
-env LEIFDB_DATA_DIR=/data/c \
+env LEIFDB_DATA_DIR=~/testdata/c \
   LEIFDB_MODE=multi \
   LEIFDB_MEMBER_NODES="localhost:16990,localhost:16991,localhost:16992" \
   LEIFDB_HOST=localhost \

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -637,10 +637,6 @@ func (n *Node) HandleVote(req *raft.VoteRequest) *raft.VoteReply {
 		// Increment term, vote for same node as previous term (is this correct?)
 		vote = false
 		msg = "Expired term vote received"
-		if n.State == mgmt.Leader {
-			n.SetTerm(n.Term+1, n.votedFor)
-			msg = msg + ", incrementing term"
-		}
 	} else if !n.CheckForeignNode(req.Candidate.Id, n.otherNodes) {
 		vote = false
 		msg = "Unknown foreign node: " + req.Candidate.Id

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -634,7 +634,6 @@ func (n *Node) HandleVote(req *raft.VoteRequest) *raft.VoteReply {
 	var msg string
 	// todo: check candidate's log details
 	if req.Term <= n.Term {
-		// Increment term, vote for same node as previous term (is this correct?)
 		vote = false
 		msg = "Expired term vote received"
 	} else if !n.CheckForeignNode(req.Candidate.Id, n.otherNodes) {

--- a/internal/raftserver/rpc_test.go
+++ b/internal/raftserver/rpc_test.go
@@ -24,7 +24,7 @@ func checkMock(addr string, known map[string]*node.ForeignNode) bool {
 	return true
 }
 
-// setupServer configurs a Database and a Node, mocks cluster membership check,
+// setupServer configures a Database and a Node, mocks cluster membership check,
 // and creates a test directory that is cleaned up after each test
 func setupServer(t *testing.T) *node.Node {
 	addr := "localhost:16990"
@@ -271,7 +271,7 @@ func TestVote(t *testing.T) {
 				Candidate:    testRaftNode,
 				LastLogIndex: -1,
 				LastLogTerm:  0},
-			expectTerm:      2,
+			expectTerm:      1,
 			expectVote:      false,
 			expectNodeState: mgmt.Leader},
 		{


### PR DESCRIPTION
When merged, this PR will:

- Avoid unnecessary term update when receiving vote request for expired term
- Update docs to remove out-of-date info
- Add configurable tag to docker make task
