### PR TITLE
Check candidates logs in vote request handler

### DIFF
--- a/internal/raftserver/rpc_test.go
+++ b/internal/raftserver/rpc_test.go
@@ -9,14 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/rs/zerolog"
+
 	db "github.com/btmorr/leifdb/internal/database"
 	"github.com/btmorr/leifdb/internal/mgmt"
 	"github.com/btmorr/leifdb/internal/node"
 	"github.com/btmorr/leifdb/internal/raft"
 	"github.com/btmorr/leifdb/internal/testutil"
 	"github.com/btmorr/leifdb/internal/util"
-	"github.com/golang/protobuf/proto"
 )
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	// zerolog.SetGlobalLevel(zerolog.DebugLevel)
+}
 
 // checkMock is used to skip membership checks during test, so that a Node will
 // respond to RPC calls without creating a full multi-node configuration
@@ -265,13 +272,13 @@ func TestVote(t *testing.T) {
 
 	testCases := []voteTestCase{
 		{
-			name: "Vote request expired term",
+			name: "Vote request current term",
 			request: &raft.VoteRequest{
 				Term:         1,
 				Candidate:    testRaftNode,
 				LastLogIndex: -1,
 				LastLogTerm:  0},
-			expectTerm:      1,
+			expectTerm:      2,
 			expectVote:      false,
 			expectNodeState: mgmt.Leader},
 		{


### PR DESCRIPTION
When merged, this PR will:

- Add checks to log handler that ensure that a candidate's log is up-to-date with any committed entries
- Add back in term bump when a leader receives a vote request for the current term (this avoids a situation where two nodes can both believe they rightly voted for different leaders in the same term)
- Add log level configuration to a couple of noisy test suites

Closes #40.
