### PR TITLE
Add docker-compose file and directions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ protobuf:
 	cp ./github.com/btmorr/leifdb/internal/raft/* ./internal/raft/
 	rm -rf ./github.com
 
-.PHONY: container
-container:
+.PHONY: linuxbin
+linuxbin:
 	env GOOS=linux GOARCH=amd64 go build -o build/leifdb
-	docker build -t leifdb:$(tag) .
+
+.PHONY: testcluster
+testcluster: linuxbin
+	make -C ui build
+	docker-compose up --build

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ For other options, such as manually running the test suite, take a look at the c
 
 There's a very basic front end! It's capable to connecting to a server, and doing read/write/delete actions. Check out the [readme](./ui) in that directory for directions on installing and running it.
 
+## Starting a demo cluster
+
+This repo includes a docker-compose specification for starting a demo cluster with 3 nodes and the UI application. To build and start the demo cluster, do:
+
+```
+make testcluster
+```
+
+This is a great way to see the cluster in action, try out the UI, or as an example for configuration. Once the applications start, you can use a web browser to open [the UI interface](http://localhost:3000), and use "localhost:8080", "localhost:8081", or "localhost:8082" to connect to any of the server nodes and search/set/delete.
+
 ## Endpoints
 
 ### Database requests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3'
+services:
+  leifdb0:
+    build: .
+    ports:
+      - "8080:8080"
+      - "16990:16990"
+    environment:
+      LEIFDB_MODE: "multi"
+      LEIFDB_HOST: "leifdb0"
+      LEIFDB_MEMBER_NODES: "leifdb0:16990,leifdb1:16991,leifdb2:16992"
+  leifdb1:
+    build: .
+    ports:
+      - "8081:8081"
+      - "16991:16991"
+    environment:
+      LEIFDB_MODE: "multi"
+      LEIFDB_HOST: "leifdb1"
+      LEIFDB_HTTP_PORT: 8081
+      LEIFDB_RAFT_PORT: 16991
+      LEIFDB_MEMBER_NODES: "leifdb0:16990,leifdb1:16991,leifdb2:16992"
+  leifdb2:
+    build: .
+    ports:
+      - "8082:8082"
+      - "16992:16992"
+    environment:
+      LEIFDB_MODE: "multi"
+      LEIFDB_HOST: "leifdb2"
+      LEIFDB_HTTP_PORT: 8082
+      LEIFDB_RAFT_PORT: 16992
+      LEIFDB_MEMBER_NODES: "leifdb0:16990,leifdb1:16991,leifdb2:16992"
+  leifui:
+    build: ./ui/
+    ports:
+      - "3000:3000"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:14-alpine
+
+RUN npm install -g serve
+
+ADD build /usr/local/ui
+
+CMD ["serve", "-l", "tcp://0.0.0.0:3000", "-s", "/usr/local/ui"]

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,4 +1,5 @@
 version = "0.1.0"
+tag ?= 0
 
 .PHONY: install
 install:
@@ -16,3 +17,7 @@ test:
 autorest:
 	npx autorest --typescript --input-file=../docs/swagger.json --output-folder=. --license-header=NONE --package-name=leifdb --package-version=$(version)
 	scripts/autorest.post.sh ./src/models/index.ts ./src/models/mappers.ts ./src/models/parameters.ts ./src/leifDbClientAPI.ts ./src/leifDbClientAPIContext.ts
+
+.PHONY: container
+container: build
+	docker build -t leifui:$(tag) .


### PR DESCRIPTION
When merged, this PR will:

- Add a docker-compose.yml file and directions for starting a demo cluster
- Modify make tasks as needed for the docker-compose job

Connecting to a node in the UI:

<img width="1722" alt="Screen Shot 2020-07-06 at 9 54 25 PM" src="https://user-images.githubusercontent.com/5034659/86690712-2b627200-bfd6-11ea-8449-b9a655bbeb9a.png">

Writing a value to the cluster in the UI:

<img width="1723" alt="Screen Shot 2020-07-06 at 9 55 02 PM" src="https://user-images.githubusercontent.com/5034659/86690756-36b59d80-bfd6-11ea-9899-0a58b6fbde96.png">

Closes #86.
