### PR TITLE
Use immutable data structure to implement database

### DIFF
--- a/gists/fork.go
+++ b/gists/fork.go
@@ -1,0 +1,28 @@
+// +build ignore
+
+package main
+
+import (
+  "fmt"
+  "time"
+
+	iradix "github.com/hashicorp/go-immutable-radix"
+)
+
+func checkTree(tree *iradix.Tree) {
+  time.Sleep(time.Second)
+  check, _ := tree.Get([]byte("something"))
+  fmt.Println("Medial:", check)
+}
+
+func main() {
+  tree := iradix.New()
+  tree, _, _ = tree.Insert([]byte("this"), "that")
+  tree, _, _ = tree.Insert([]byte("something"), "else")
+  tree, _, _ = tree.Insert([]byte("what?"), "I didn't say anything...")
+  go checkTree(tree)
+  tree, _, _ = tree.Insert([]byte("something"), "unspeakable")
+  time.Sleep(time.Second * 2)
+  res, _ := tree.Get([]byte("something"))
+  fmt.Println("Finial:", res)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/spec v0.19.8 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/golang/protobuf v1.4.2
+	github.com/hashicorp/go-immutable-radix v1.2.0
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/rs/zerolog v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,11 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/hashicorp/go-immutable-radix v1.2.0 h1:l6UW37iCXwZkZoAbEYnptSHVE/cQ5bOTPYG5W3vf9+8=
+github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1,28 +1,34 @@
 package database
 
+import iradix "github.com/hashicorp/go-immutable-radix"
+
 // A Database is a key-value store
 type Database struct {
-	underlying map[string]string
+	underlying *iradix.Tree
 }
 
-// Get retreives the value for a key (empty string if key does not exist)
+// Get retrieves the value for a key (empty string if key does not exist)
 func (d *Database) Get(key string) string {
-	r := d.underlying[key]
-	return r
+	r, _ := d.underlying.Get([]byte(key))
+	if r == nil {
+		return ""
+	}
+	return r.(string)
 }
 
 // Set assigns a value to a key
 func (d *Database) Set(key string, value string) {
-	d.underlying[key] = value
+	d.underlying, _, _ = d.underlying.Insert([]byte(key), value)
 }
 
 // Delete removes a key and value from the store
 func (d *Database) Delete(key string) {
-	delete(d.underlying, key)
+	d.underlying, _, _ = d.underlying.Delete([]byte(key))
 }
 
 // NewDatabase returns an initialized Database
 func NewDatabase() *Database {
 	return &Database{
-		underlying: make(map[string]string)}
+		underlying: iradix.New(),
+	}
 }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -3,13 +3,7 @@
 package database
 
 import (
-	"bufio"
-	"log"
-	"os"
-	"strings"
 	"testing"
-
-	"github.com/btmorr/leifdb/internal/util"
 )
 
 func TestDatabase(t *testing.T) {
@@ -33,36 +27,4 @@ func TestDatabase(t *testing.T) {
 	if r3 != "" {
 		t.Errorf("Read deleted key should return empty string, got: %s\n", r3)
 	}
-}
-
-func BenchmarkDatabasePersist(b *testing.B) {
-	// testing file write in relation to snapshotting--this doesn't test
-	// or prove anything about the live system currently, but leaving it
-	// here for now until there is an actual snapshot behavior to
-	// benchmark
-	testDir, err := util.CreateTmpDir(".tmp-leifdb")
-	if err != nil {
-		log.Fatalln("Error creating test dir:", err)
-	}
-	b.Cleanup(func() {
-		util.RemoveTmpDir(testDir)
-	})
-
-	d := NewDatabase()
-	for i := 0; i < 1000000; i++ {
-		s := string(i)
-		// repeat of 10 yields a db file around 44Mb
-		// repeat of 1000 yields a file around 3.7Gb
-		d.Set(s, strings.Repeat(s, 10))
-	}
-	// b.ResetTimer()
-	f, err := os.Create(testDir + "/data")
-	if err != nil {
-		panic(err)
-	}
-	w := bufio.NewWriter(f)
-	for k, v := range d.underlying {
-		w.WriteString(k + ": " + v + "\n")
-	}
-	w.Flush()
 }


### PR DESCRIPTION
When merged, this PR will:

- Use an immutable data structure under Database
- Remove no-longer-relevant benchmark

This is necessary in order to be able to safely implement snapshots (#83)
