### PR TITLE
Add snapshot manager

### DIFF
--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -70,7 +70,7 @@ const (
 type ServerConfig struct {
 	Host              string
 	DataDir           string
-	SnapshotThreshold int
+	SnapshotThreshold int64
 	RetainNSnapshots  int
 	RaftPort          string
 	RaftAddr          string
@@ -225,9 +225,9 @@ func BuildServerConfig() *ServerConfig {
 
 	// by default, snapshot when log is 1Gb
 	snapshotThreshold := getEnvDefault(
-		"LEIFDB_SNAPSHOT_THRESHOLD", func() string { return string(1024 * 1024 * 1024) })
+		"LEIFDB_SNAPSHOT_THRESHOLD", func() string { return strconv.Itoa(1024 * 1024 * 1024) })
 	verifyInt(snapshotThreshold)
-	snapshotBytes, _ := strconv.Atoi(snapshotThreshold)
+	snapshotBytes, _ := strconv.ParseInt(snapshotThreshold, 10, 64)
 
 	retain := getEnvDefault(
 		"LEIFDB_RETAIN_N_SNAPSHOTS", func() string { return "1" })

--- a/internal/mgmt/shapshotmanager.go
+++ b/internal/mgmt/shapshotmanager.go
@@ -1,0 +1,137 @@
+package mgmt
+
+// snapshot manager can be aware of node and database, but node and database
+// should not be aware of managers
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	db "github.com/btmorr/leifdb/internal/database"
+	"github.com/btmorr/leifdb/internal/node"
+)
+
+const prefix = "ldbsnapshot"
+
+func findExistingSnapshots(dataDir string) ([]string, int) {
+	snapshotFiles := []string{}
+	nextIndex := 0
+	files, err := ioutil.ReadDir(dataDir)
+	if err != nil {
+		log.Error().Err(err).Msgf("error listing %s", dataDir)
+	} else {
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), prefix) {
+				snapshotFiles = append(snapshotFiles, filepath.Join(dataDir, file.Name()))
+			}
+		}
+		sort.Strings(snapshotFiles)
+	}
+	log.Info().Int("count", len(snapshotFiles)).Msg("found snapshots")
+	if len(snapshotFiles) > 0 {
+		latest := snapshotFiles[len(snapshotFiles)-1]
+		_, filename := filepath.Split(latest)
+		index, err := strconv.Atoi(strings.TrimPrefix(filename, prefix))
+		if err != nil {
+			log.Error().Err(err).Msg("error parsing latest snapshot index")
+		} else {
+			log.Info().Int("index", index).Msg("latest snapshot")
+			nextIndex = index + 1
+		}
+	}
+	return snapshotFiles, nextIndex
+}
+
+func cloneAndSerialize(node *node.Node) ([]byte, error) {
+	node.Lock()
+	commitIndex := node.CommitIndex
+	clone := db.Clone(node.Store)
+	node.Unlock()
+
+	log.Info().
+		Int64("commit index", commitIndex).
+		Msg("doing snapshot")
+	return db.BuildSnapshot(clone)
+}
+
+func persistSnapshot(data []byte, filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+	w.Flush()
+	return nil
+}
+
+func StartSnapshotManager(
+	dataDir string,
+	logFile string,
+	threshold int64,
+	retain int,
+	node *node.Node) {
+	t := time.NewTicker(time.Minute)
+
+	snapshotFiles, nextIndex := findExistingSnapshots(dataDir)
+
+	go func() {
+		for {
+			select {
+			case <-t.C:
+				// check file size
+				fi, _ := os.Stat(logFile)
+				size := fi.Size()
+				log.Info().
+					Int64("log file size", size).
+					Int64("threshold", threshold).
+					Msg("snapshot check")
+				if size > threshold {
+					snapshot, err := cloneAndSerialize(node)
+					if err != nil {
+						log.Error().Err(err).Msg("error building snapshot")
+						continue
+					}
+
+					filename := fmt.Sprintf("%s%06d", prefix, nextIndex)
+					fullPath := filepath.Join(dataDir, filename)
+					err = persistSnapshot(snapshot, fullPath)
+					if err != nil {
+						log.Error().Err(err).Msg("error persisting snapshot")
+						continue
+					}
+
+					nextIndex++
+					snapshotFiles = append(snapshotFiles, fullPath)
+					// todo: trigger node log compaction
+				}
+				for len(snapshotFiles) > retain {
+					drop := snapshotFiles[0]
+					log.Info().Str("filename", drop).Msg("removing snapshot")
+					err := os.Remove(drop)
+					if err != nil {
+						log.Error().
+							Err(err).
+							Str("filename", drop).
+							Msg("error removing log file")
+					}
+					snapshotFiles = snapshotFiles[1:]
+				}
+			default:
+			}
+		}
+	}()
+}

--- a/internal/mgmt/snapshotmanager_test.go
+++ b/internal/mgmt/snapshotmanager_test.go
@@ -1,0 +1,111 @@
+// +build unit
+
+package mgmt
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	db "github.com/btmorr/leifdb/internal/database"
+	"github.com/btmorr/leifdb/internal/node"
+	"github.com/btmorr/leifdb/internal/util"
+)
+
+// checkMock is used to skip membership checks during test, so that a Node will
+// respond to RPC calls without creating a full multi-node configuration
+func checkMock(addr string, known map[string]*node.ForeignNode) bool {
+	return true
+}
+
+func setupTestDir(t *testing.T) string {
+	testDir, err := util.CreateTmpDir(".tmp-leifdb")
+	if err != nil {
+		log.Fatalln("Error creating test dir:", err)
+	}
+	t.Cleanup(func() {
+		util.RemoveTmpDir(testDir)
+	})
+	return testDir
+}
+
+// setupServer configures a Database and a Node, mocks cluster membership check,
+// and creates a test directory that is cleaned up after each test
+func setupServer(t *testing.T) *node.Node {
+	addr := "localhost:16990"
+	clientAddr := "localhost:8080"
+
+	testDir := setupTestDir(t)
+	store := db.NewDatabase()
+
+	config := node.NewNodeConfig(testDir, addr, clientAddr, make([]string, 0, 0))
+	n, _ := node.NewNode(config, store)
+	n.CheckForeignNode = checkMock
+	return n
+}
+
+func TestFindExisting(t *testing.T) {
+	testDir := setupTestDir(t)
+
+	// create dummy snapshot files
+	for _, n := range []string{"000013", "000014"} {
+		fileName := filepath.Join(testDir, prefix+n)
+		_, err := os.Stat(fileName)
+		if os.IsNotExist(err) {
+			file, err := os.Create(fileName)
+			if err != nil {
+				log.Fatal(err)
+			}
+			file.Close()
+		}
+	}
+
+	snapshots, nextIndex := findExistingSnapshots(testDir)
+
+	if len(snapshots) != 2 {
+		t.Errorf("Expected 2 snapshots found, got %d\n", len(snapshots))
+	}
+	if nextIndex != 15 {
+		t.Errorf("Expected next index of 15, got %d\n", nextIndex)
+	}
+}
+
+func TestCloneAndSerialize(t *testing.T) {
+	n := setupServer(t)
+	n.Store.Set("ice", "cream")
+	n.Store.Set("straw", "bale")
+	var snapshot []byte
+	var err error
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		snapshot, err = cloneAndSerialize(n)
+		wg.Done()
+	}()
+	// simulate raft write
+	n.Lock()
+	n.Store.Set("straw", "berry")
+	n.Unlock()
+
+	wg.Wait()
+	fmt.Println("=-------> snapshot <-------=")
+	fmt.Println(string(snapshot))
+	reconstituted, err := db.InstallSnapshot(snapshot)
+	if err != nil {
+		t.Errorf("Error installing snapshot: %v\n", err)
+	}
+
+	ice := reconstituted.Get("ice")
+	if ice != "cream" {
+		t.Errorf("Expected ice cream but got ice %s\n", ice)
+	}
+
+	straw := reconstituted.Get("straw")
+	if straw != "bale" {
+		t.Errorf("Expected straw bale but got straw %s\n", straw)
+	}
+}

--- a/internal/mgmt/snapshotmanager_test.go
+++ b/internal/mgmt/snapshotmanager_test.go
@@ -3,12 +3,12 @@
 package mgmt
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	db "github.com/btmorr/leifdb/internal/database"
 	"github.com/btmorr/leifdb/internal/node"
@@ -86,14 +86,13 @@ func TestCloneAndSerialize(t *testing.T) {
 		snapshot, err = cloneAndSerialize(n)
 		wg.Done()
 	}()
-	// simulate raft write
+	// simulate raft write starting during clone
+	time.Sleep(time.Microsecond * 50)
 	n.Lock()
 	n.Store.Set("straw", "berry")
 	n.Unlock()
 
 	wg.Wait()
-	fmt.Println("=-------> snapshot <-------=")
-	fmt.Println(string(snapshot))
 	reconstituted, err := db.InstallSnapshot(snapshot)
 	if err != nil {
 		t.Errorf("Error installing snapshot: %v\n", err)

--- a/internal/mgmt/statemanager_test.go
+++ b/internal/mgmt/statemanager_test.go
@@ -9,6 +9,8 @@ package mgmt
 import (
 	"testing"
 	"time"
+
+	"github.com/btmorr/leifdb/internal/node"
 )
 
 func TestManager(t *testing.T) {
@@ -37,7 +39,7 @@ func TestManager(t *testing.T) {
 			return
 		})
 
-	if mgmt.state.stateType() != Follower {
+	if mgmt.state.stateType() != node.Follower {
 		t.Errorf(
 			"Expected state to be Follower but got %s\n", mgmt.state.stateType())
 	}
@@ -46,7 +48,7 @@ func TestManager(t *testing.T) {
 	if electionCounter != 1 {
 		t.Errorf("Expected %d elections, got %d\n", 1, electionCounter)
 	}
-	if mgmt.state.stateType() != Leader {
+	if mgmt.state.stateType() != node.Leader {
 		t.Errorf(
 			"Expected state to be Leader after election, but got %s\n",
 			mgmt.state.stateType())
@@ -67,7 +69,7 @@ func TestManager(t *testing.T) {
 		resetFlag <- true
 	}()
 	time.Sleep(time.Millisecond * 2)
-	if mgmt.state.stateType() != Follower {
+	if mgmt.state.stateType() != node.Follower {
 		t.Errorf(
 			"Expected state to be Follower, but got %s\n", mgmt.state.stateType())
 	}
@@ -76,7 +78,7 @@ func TestManager(t *testing.T) {
 	if electionCounter != 2 {
 		t.Errorf("Expected %d elections, got %d\n", 2, electionCounter)
 	}
-	if mgmt.state.stateType() != Follower {
+	if mgmt.state.stateType() != node.Follower {
 		t.Errorf(
 			"Expected state to be Follower after failed election, but got %s\n",
 			mgmt.state.stateType())
@@ -96,7 +98,7 @@ func TestManager(t *testing.T) {
 	if electionCounter != 2 {
 		t.Errorf("Expected %d elections, got %d\n", 2, electionCounter)
 	}
-	if mgmt.state.stateType() != Follower {
+	if mgmt.state.stateType() != node.Follower {
 		t.Errorf(
 			"Expected state to still be Follower after resets, but got %s\n",
 			mgmt.state.stateType())

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog"
 
 	db "github.com/btmorr/leifdb/internal/database"
-	"github.com/btmorr/leifdb/internal/mgmt"
 	"github.com/btmorr/leifdb/internal/raft"
 	"github.com/btmorr/leifdb/internal/testutil"
 	"github.com/btmorr/leifdb/internal/util"
@@ -59,7 +58,7 @@ func TestNewForeignNode(t *testing.T) {
 
 func TestAvailabilityReport(t *testing.T) {
 	n := setupNode(t)
-	n.State = mgmt.Leader
+	n.State = Leader
 
 	host1 := "localhost:12345"
 	host2 := "localhost:23456"
@@ -184,7 +183,7 @@ func TestVote(t *testing.T) {
 	n := setupNode(t)
 
 	// set up node as if it is Leader with two logs committed
-	n.State = mgmt.Leader
+	n.State = Leader
 	n.SetTerm(2, n.RaftNode)
 	n.Log = &raft.LogStore{
 		Entries: []*raft.LogRecord{
@@ -202,7 +201,7 @@ func TestVote(t *testing.T) {
 			},
 		},
 	}
-	n.commitIndex = 1
+	n.CommitIndex = 1
 
 	testRaftNode := &raft.Node{Id: "localhost:16999", ClientAddr: "localhost:8089"}
 

--- a/internal/raftserver/rpc_test.go
+++ b/internal/raftserver/rpc_test.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	db "github.com/btmorr/leifdb/internal/database"
-	"github.com/btmorr/leifdb/internal/mgmt"
 	"github.com/btmorr/leifdb/internal/node"
 	"github.com/btmorr/leifdb/internal/raft"
 	"github.com/btmorr/leifdb/internal/testutil"
@@ -247,7 +246,7 @@ type voteTestCase struct {
 	request         *raft.VoteRequest
 	expectTerm      int64
 	expectVote      bool
-	expectNodeState mgmt.Role
+	expectNodeState node.Role
 }
 
 func TestVote(t *testing.T) {
@@ -260,14 +259,14 @@ func TestVote(t *testing.T) {
 
 	s := server{Node: n}
 	// Simulating node in leader position, rather than adding a time.Sleep
-	n.State = mgmt.Leader
+	n.State = node.Leader
 	n.DoElection()
 	// mock behavior of StateManager
 	go func() {
 		for {
 			select {
 			case <-n.Reset:
-				n.State = mgmt.Follower
+				n.State = node.Follower
 			default:
 			}
 		}
@@ -283,7 +282,7 @@ func TestVote(t *testing.T) {
 				LastLogTerm:  0},
 			expectTerm:      2,
 			expectVote:      false,
-			expectNodeState: mgmt.Leader},
+			expectNodeState: node.Leader},
 		{
 			name: "Vote request valid",
 			request: &raft.VoteRequest{
@@ -293,7 +292,7 @@ func TestVote(t *testing.T) {
 				LastLogTerm:  0},
 			expectTerm:      3,
 			expectVote:      true,
-			expectNodeState: mgmt.Follower}}
+			expectNodeState: node.Follower}}
 
 	for _, tc := range testCases {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func (ctl *Controller) handleWrite(c *gin.Context) {
 
 	// Short circuit, if we are not the leader right now, we return
 	// a redirect to the current presumptive leader
-	if ctl.Node.State != mgmt.Leader {
+	if ctl.Node.State != node.Leader {
 		// We could be in a state where we don't have a leader elected yet to
 		// redirect to, at this point this server can't do much
 		if ctl.Node.RedirectLeader() == "" {
@@ -161,7 +161,7 @@ func (ctl *Controller) handleDelete(c *gin.Context) {
 
 	// Short circuit, if we are not the leader right now, we return
 	// a redirect to the current presumptive leader
-	if ctl.Node.State != mgmt.Leader {
+	if ctl.Node.State != node.Leader {
 		// We could be in a state where we don't have a leader elected yet to
 		// redirect to, at this point this server can't do much
 		if ctl.Node.RedirectLeader() == "" {
@@ -253,10 +253,17 @@ func main() {
 		},
 		appendInterval, // Period for doing append job when Leader
 		func() {
-			if n.State == mgmt.Leader {
+			if n.State == node.Leader {
 				n.SendAppend(0, n.Term)
 			}
 		}) // Call when append ticker cycles
+
+	mgmt.StartSnapshotManager(
+		config.DataDir,
+		config.LogFile,
+		cfg.SnapshotThreshold,
+		cfg.RetainNSnapshots,
+		n)
 
 	raftPortString := fmt.Sprintf(":%s", cfg.RaftPort)
 	clientPortString := fmt.Sprintf(":%s", cfg.ClientPort)

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	db "github.com/btmorr/leifdb/internal/database"
-	"github.com/btmorr/leifdb/internal/mgmt"
 	"github.com/btmorr/leifdb/internal/node"
 	"github.com/btmorr/leifdb/internal/raft"
 	"github.com/btmorr/leifdb/internal/util"
@@ -39,7 +38,7 @@ func setupServer(t *testing.T) (*gin.Engine, *node.Node) {
 	config := node.NewNodeConfig(testDir, addr, clientAddr, make([]string, 0, 0))
 	n, _ := node.NewNode(config, store)
 	router := buildRouter(n)
-	n.State = mgmt.Leader
+	n.State = node.Leader
 	return router, n
 }
 
@@ -92,11 +91,11 @@ func TestReadAfterWrite(t *testing.T) {
 }
 
 func TestWriteRedirect(t *testing.T) {
-	router, node := setupServer(t)
+	router, n := setupServer(t)
 
 	// Change our node so we become a follower
-	node.State = mgmt.Follower
-	node.SetTerm(node.Term+1, &raft.Node{
+	n.State = node.Follower
+	n.SetTerm(n.Term+1, &raft.Node{
 		Id:         "localhost:16991",
 		ClientAddr: "localhost:8081",
 	})
@@ -183,11 +182,11 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteRedirect(t *testing.T) {
-	router, node := setupServer(t)
+	router, n := setupServer(t)
 
 	// Change our node so we become a follower
-	node.State = mgmt.Follower
-	node.SetTerm(node.Term+1, &raft.Node{
+	n.State = node.Follower
+	n.SetTerm(n.Term+1, &raft.Node{
 		Id:         "localhost:16991",
 		ClientAddr: "localhost:8081",
 	})


### PR DESCRIPTION
When merged, this PR will:

- Add snapshot manager
- Make Node commit index public for use in snapshot manager
- Move `Role` from mgmt to node to prevent circular import

Closes #83.
