### PR TITLE
Compact logs once snapshot is completed

### DIFF
--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -63,7 +63,7 @@ func TestSnapshotRoundtrip(t *testing.T) {
 	d0.Set("2", "two")
 	d0.Set("3", "three")
 
-	snapshot, err := BuildSnapshot(d0)
+	snapshot, err := BuildSnapshot(d0, Metadata{2, 1})
 	if err != nil {
 		t.Errorf("Error in BuildSnapshot: %v\n", err)
 	}


### PR DESCRIPTION
When merged, this PR will:

- Include metadata about log index and term with snapshot
- Compact logs after snapshot is completed
- Modify both halves of log append RPC to account for snapshot offsets

Closes #112
