### PR TITLE
Replace 'edge' branch references with 'main'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,5 @@ cc: @btmorr
   take a look in the Contributing Guide, or go ahead and post and
   the maintainers will help out as much as possible.
 
-  https://github.com/btmorr/leifdb/blob/edge/CONTRIBUTING.md
+  https://github.com/btmorr/leifdb/blob/main/CONTRIBUTING.md
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To help understand the project layout further, or to modify it, check out the RE
 
 ### Versioning and release
 
-The version number is currently determined by a variable in "version.sh". The `make app` command builds a binary that includes this version number (and also the name of the current git branch, if not "edge"). Remember to update this variable before tagging a commit as a release in GitHub, and also make sure the new tag matches the variable.
+The version number is currently determined by a variable in "version.sh". The `make app` command builds a binary that includes this version number (and also the name of the current git branch, if not "main"). Remember to update this variable before tagging a commit as a release in GitHub, and also make sure the new tag matches the variable.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,6 @@ Aside from the Raft papers themselves ([short] and [extended]) and the [CRaft] p
 [report-card-badge]: https://goreportcard.com/badge/github.com/btmorr/leifdb
 [license]: https://github.com/btmorr/leifdb/LICENSE
 [license-badge]: https://img.shields.io/github/license/btmorr/leifdb.svg
-[build]: https://dl.circleci.com/status-badge/redirect/gh/btmorr/leifdb/tree/edge
-[build-badge]: https://dl.circleci.com/status-badge/img/gh/btmorr/leifdb/tree/edge.svg?style=svg
+[build]: https://dl.circleci.com/status-badge/redirect/gh/btmorr/leifdb/tree/main
+[build-badge]: https://dl.circleci.com/status-badge/img/gh/btmorr/leifdb/tree/main.svg?style=svg
 [contributing guide]: ./CONTRIBUTING.md

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -21,7 +21,7 @@ var doc = `{
         "contact": {},
         "license": {
             "name": "MIT",
-            "url": "https://github.com/btmorr/leifdb/blob/edge/LICENSE"
+            "url": "https://github.com/btmorr/leifdb/blob/main/LICENSE"
         },
         "version": "{{.Version}}"
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,7 +6,7 @@
         "contact": {},
         "license": {
             "name": "MIT",
-            "url": "https://github.com/btmorr/leifdb/blob/edge/LICENSE"
+            "url": "https://github.com/btmorr/leifdb/blob/main/LICENSE"
         },
         "version": "0.1"
     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -31,7 +31,7 @@ info:
   description: A distributed K-V store using the Raft protocol
   license:
     name: MIT
-    url: https://github.com/btmorr/leifdb/blob/edge/LICENSE
+    url: https://github.com/btmorr/leifdb/blob/main/LICENSE
   title: LeifDb Client API
   version: "0.1"
 paths:

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -896,7 +896,7 @@ func (n *Node) HandleAppend(req *raft.AppendRequest) *raft.AppendReply {
 		// reset the election timer on append from a valid leader (even if
 		// not matched)--this duplicates the reset in `validateAppend`, in order to
 		// ensure that the time it takes to do all of the operations in this
-		// handler effectively happend "instantaneously" from the perspective of
+		// handler effectively happened "instantaneously" from the perspective of
 		// the election timeout
 		n.resetElectionTimer()
 	}

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var (
 // @version 0.1
 // @description A distributed K-V store using the Raft protocol
 // @license.name MIT
-// @license.url https://github.com/btmorr/leifdb/blob/edge/LICENSE
+// @license.url https://github.com/btmorr/leifdb/blob/main/LICENSE
 
 // Controller wraps routes for HTTP interface
 type Controller struct {

--- a/version.sh
+++ b/version.sh
@@ -4,7 +4,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\//-/')
 SHORT_HASH=$(git rev-parse --short HEAD)
 VERSION="0.2.0-beta.1"
 
-if [ $BRANCH == "edge" ]
+if [ $BRANCH == "main" ]
 then
     echo $VERSION
 else


### PR DESCRIPTION
When merged, this PR will:

- Replace references in code and docs to `edge` with `main`
